### PR TITLE
Don't head directories in has-python-shebang test

### DIFF
--- a/etc/rbenv.d/rehash/pyenv-binstubs.bash
+++ b/etc/rbenv.d/rehash/pyenv-binstubs.bash
@@ -44,7 +44,7 @@ register_user_binstubs()
   potential_path="$(get_userbase)/bin"
   for shim in $potential_path/*; do
     # potential_path is executable AND a python script
-    if [ -x "$shim" ] && head -n1 "$shim" | grep -q '^#.*python'; then
+    if [ ! -d "$shim" ] && [ -x "$shim" ] && head -n1 "$shim" | grep -q '^#.*python'; then
       register_shim "${shim##*/}"
     fi
   done


### PR DESCRIPTION
Add -f is-file to conditional expression in register_user_binstubs because a user's bin directory may contain subdirectories which otherwise would generate "head: error reading '...': Is a directory" messages during user binstubs registration.

You might prefer to recurse into them as you do during register_binstubs for system and pyenv  bindirs, but since in my case that was unnecessary I went with the simpler fix to start.